### PR TITLE
Writing some tests: Part II

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ The goal for this transpiler can be one of two:
 2. Minimal use of semicolons merely to ensure consistent behavior upon transpilation.
 
 For now, I'm sticking with #2.
+
+### 2025 SEMICOLON UPDATE
+
+I made the official executive decision to just eliminate the semicolon altogether (except, of course, inside for loop instantiations).
+
+The produced code looks so much nicer.
+
+And, most importantly, modern JavaScript is just fine with it and everything runs without a hitch.
+
+In fact, I've been noticing in other projects that TypeScript conventions tend to actually *insist* on avoiding semicolons.

--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@
 from settings import LOG_FILE
 
 class ASTConfig:
-    def __init__(self, assign: str = 'const', wrap_return: str = "()", tuples_in_curly_braces: bool = True, tuples_in_square_brackets: bool = False, debug: bool = False, log_file: str = LOG_FILE):
+    def __init__(self, assign: str = 'let', wrap_return: str = "()", tuples_in_curly_braces: bool = True, tuples_in_square_brackets: bool = False, debug: bool = False, log_file: str = LOG_FILE):
         self.assign = assign
         self.wrap_return = wrap_return
         self.tuples_in_curly_braces = tuples_in_curly_braces
@@ -10,8 +10,9 @@ class ASTConfig:
 
         self.debug = debug
 
-        self.assign = 'let'
         self.assign = 'const'
+        self.assign = 'var'
+        self.assign = 'let'
 
         self.wrap_return = "()"
         self.list_sep = ", "

--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 """"""
 from src.hooks import Hooks
-from src.logging import Logging
+from src.logger import Logger
 from src.main import Code
 from src.parsing.main import Visitor
 
 
-class Main(Code, Visitor, Hooks, Logging):
+class Main(Code, Visitor, Hooks, Logger):
     def throw(self, e: str):
         raise Exception(e)
 

--- a/special_types.py
+++ b/special_types.py
@@ -1,0 +1,13 @@
+""""""
+
+class var:
+    def __init__(self, val):
+        self.val = val
+
+class const:
+    def __init__(self, val):
+        self.val = val
+
+class let:
+    def __init__(self, val):
+        self.val = val

--- a/src/hooks.py
+++ b/src/hooks.py
@@ -131,6 +131,36 @@ class Hooks:
         #print("JOINED STRING TYPES:", set(joined_string_types))
         #print("FOR LOOP TYPES:", set(for_loop_types))
 
+        args = loc.get('args')
+        self.current_code_context = ""
+        if args:
+            self.print_code(args)
+
     def post_hook(self, loc):
         #print("POST HOOK", loc['func'].__name__, loc['args'][0], loc)
         ...
+
+    def print_code(self, args):
+        if not args:
+            print("Nothing here", type(args), args)
+            raise Exception("Guh?")
+        elif type(args) == list or type(args) == tuple:
+            for i in range(len(args)):
+                self.print_code(args[i])
+                return
+        print(type(args), args)
+        e = args
+        a, b, c, d = e.lineno, e.col_offset, e.end_col_offset, e.end_lineno
+        # print(f"LINE: {a}, COL: {b}, END COL: {c}, END LINE: {d}")
+        code_str = self.code
+        l = code_str.split('\n')[a - 1:d]
+        print("INCOMING CODE:")
+        for i, line in enumerate(l):
+            if i == 0:
+                line = f"[lineno: {a + i}]: {line[b:]}"
+                #print(line)
+            elif i == len(l) - 1:
+                line = f"[lineno: {a + i}]: {line[:c]}"
+                #print(line)
+            self.current_code_context += line
+        print("--------------")

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,5 +1,53 @@
 """"""
+import logging
 
-class Logging:
-    def log(self, msg: str):
-        ...
+class CustomFormatter(logging.Formatter):
+    grey = "\x1b[38;20m"
+    yellow = "\x1b[33;20m"
+    green = "\x1b[32;20m"
+    black = "\x1b[30;20m"
+    red = "\x1b[31;20m"
+    bold_red = "\x1b[31;1m"
+    reset = "\x1b[0m"
+    format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+
+    FORMATS = {
+        #logging.DEBUG: green + format + reset,
+        logging.DEBUG: black + format + reset,
+        logging.INFO: grey + format + reset,
+        logging.WARNING: yellow + format + reset,
+        logging.ERROR: red + format + reset,
+        logging.CRITICAL: bold_red + format + reset
+    }
+
+    def format(self, record):
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)
+
+class Logger:
+    def __init__(self, name: str = 'logger', level: int = logging.WARN):
+        logging.basicConfig()
+        self._name = name
+        self._level = level
+        self._logger = logging.getLogger(name)
+        #self._logger = logging.getLogger(__name__)
+        self._logger = logging.getLogger(name)
+        self._logger.propagate = False
+        self._handler = logging.StreamHandler()
+
+        self.configure()
+
+    def configure(self):
+        #formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        self._handler.setFormatter(CustomFormatter())
+        self._logger.handlers = [self._handler]
+        self._logger.setLevel(self._level)
+        logging.basicConfig(level=self._level, format='%(message)s')
+
+    def debug(self, msg: str, *args, **kwargs): self._logger.debug(msg, *args, **kwargs)
+    def info(self, msg: str, *args, **kwargs): self._logger.info(msg, *args, **kwargs)
+    def warning(self, msg: str, *args, **kwargs): self._logger.warning(msg, *args, **kwargs)
+    def warn(self, msg: str, *args, **kwargs): self._logger.warning(msg, *args, **kwargs)
+    def error(self, msg: str, *args, **kwargs): self._logger.error(msg, *args, **kwargs)
+

--- a/src/parsing/main.py
+++ b/src/parsing/main.py
@@ -390,7 +390,7 @@ class Visitor:
         if len(e.generators) > 1: raise Exception("TODO: Multiple generators in list comprehension...")
         if len(e.generators[0].ifs): raise Exception("TODO: If statements in list comprehension...")
         if e.generators[0].is_async: raise Exception("TODO: Async list comprehension...")
-        return f"[{self.process_statement(e.elt)} for {e.generators[0].target.id} in {self.process_statement(e.generators[0].iter)}]"
+        return f"({self.process_statement(e.elt)} for {e.generators[0].target.id} in {self.process_statement(e.generators[0].iter)})"
 
     def process_dict_comp(self, e) -> str:
         if len(e.generators) > 1: raise Exception("TODO: Multiple generators in dict comprehension...")

--- a/src/parsing/main.py
+++ b/src/parsing/main.py
@@ -33,9 +33,9 @@ class Visitor:
     def process_body(self, body: BodyType, cls: bool = False) -> str:
         s = ''
         for node in body:
-            s += self.process_statement(node, cls=cls)# + ";"
+            s += self.process_statement(node, cls=cls)
             if len(s) > 0:
-                s += ';\n'
+                s += '\n'
         return s
 
     def process_left(self, left) -> str:

--- a/src/parsing/main.py
+++ b/src/parsing/main.py
@@ -155,6 +155,15 @@ class Visitor:
     @pre_hook_wrapper
     @post_hook_wrapper
     def process_named_call(self, call: ast.Call) -> str:
+        # FOR DEBUG PURPOSE, PRINT CONTENT OF PYTHON CODE AS A STRING...
+        if self.config.debug:
+            print("---------- START OF FUNCTION CALL ----------")
+            if type(call.func) == ast.Name:
+                print(call.func.id, call.args)
+            elif type(call.func) == ast.Attribute:
+                print(call.func.value, call.func.attr, call.args)
+            print(self.current_code_context)
+            print("---------- END OF FUNCTION CALL ----------")
         ## TODO: REFACTOR THIS... ##
         content = False
         if type(call.func) == Call:
@@ -301,6 +310,9 @@ class Visitor:
     @post_hook_wrapper
     def process_assign(self, e, augment = False) -> str:
         augment_string = '+' if augment else ''
+        #print("CURRENT CODE CONTEXT")
+        #print(self.current_code_context)
+        #if 'my_special_var' in self.current_code_context: breakpoint()
         # TODO: Handle reassignment to already declared consts/vars... #
         ## Note that this may involve some kind of DIY stack trace implementation to keep track of local variables... ##
         # TODO: Proper handling of semicolons at the end of statements... #

--- a/src/parsing/main.py
+++ b/src/parsing/main.py
@@ -173,6 +173,9 @@ class Visitor:
             except IndexError:
                 raise Exception("EMPTY DICT???")
 
+        if function_name == 'super':
+            return f"super({', '.join([self.process_arg(arg) for arg in call.args])})"
+
         if function_name == 'ternary':
             return self.process_ternary(call)
 
@@ -557,7 +560,14 @@ class Visitor:
     @pre_hook_wrapper
     @post_hook_wrapper
     def process_cls(self, cls: ClsType) -> str:
+        # Note that JavaScript cannot handle multiple inheritence in a straightforward manner.
+        # You would have to create a mixin (a separate class), which is a bit out of the scope of this project.
+        inherits = ''
+        if cls.bases:
+            if len(cls.bases) > 1:
+                raise Exception("JS does not handle multiple inheritence like this. You must define a mixin yourself.")
+            inherits += ' extends '
+            inherits += cls.bases[0].id
         self.direct_parent = ('cls', cls.name)
         body = self.process_body(cls.body, cls=True)
-        inherits = ''
         return f"class {cls.name}{inherits} {{{body}}}"

--- a/src/parsing/main.py
+++ b/src/parsing/main.py
@@ -109,11 +109,11 @@ class Visitor:
             return self.process_attribute_call(body.value)
         last_attr = body.attr
         if type(body.value) == Name:
-            if self.config.debug: print(f"{body.value} IS A NAME... NO RECURSION...")
+            #if self.config.debug: print(f"{body.value} IS A NAME... NO RECURSION...")
             v = body.value.id
             s = self.config._self + s if v == 'self' else v + s
         else:
-            if self.config.debug: print("NOW RECURSING...")
+            #if self.config.debug: print("NOW RECURSING...")
             s = self.process_attribute(body.value, s) + s
         s += "." + last_attr
         return s
@@ -271,7 +271,7 @@ class Visitor:
     @return_func
     def process_return(self, r) -> str:
         ## NOTE: LOTS OF SPECIAL CASES FOR REACT... ##
-        if self.config.debug: print("RETURN", type(r), r)
+        #if self.config.debug: print("RETURN", type(r), r)
         expr = r.value
         if type(expr) == Tuple:
             raise Exception(f"TODO: Return of {str(expr)}")
@@ -291,7 +291,7 @@ class Visitor:
         # TODO: Proper handling of semicolons at the end of statements... #
 
         ## TODO: Also, multiple assignments in same statement...
-        if self.config.debug: print("ASSIGN")
+        #if self.config.debug: print("ASSIGN")
         targets = ", ".join([self.process_target(t) for t in e.targets]) if not augment else self.process_statement(e.target)
         new = 'new ' if type(e.value) == Call else ''
         if type(e.value) == ast.Call:

--- a/src/parsing/main.py
+++ b/src/parsing/main.py
@@ -454,12 +454,9 @@ class Visitor:
     @pre_hook_wrapper
     @post_hook_wrapper
     def process_except(self, e: ast.ExceptHandler) -> str:
-        # TODO...
-        raise Exception("TODO: Implement except block for try/except")
-        return f"console.log(e)"
-        print(e)
-        breakpoint()
-        print()
+        # logger.warn...
+        print(f"WARNING: In JS you need to handle specific error types (i.e. {e.type.id}) internally inside the `catch` block.")
+        return self.process_body(e.body)
 
     # TODO: STILL NEEDS TYPING...
     @pre_hook_wrapper

--- a/src/parsing/main.py
+++ b/src/parsing/main.py
@@ -293,13 +293,31 @@ class Visitor:
         ## TODO: Also, multiple assignments in same statement...
         if self.config.debug: print("ASSIGN")
         targets = ", ".join([self.process_target(t) for t in e.targets]) if not augment else self.process_statement(e.target)
-        val = self.process_statement(e.value)
         new = 'new ' if type(e.value) == Call else ''
+        if type(e.value) == ast.Call:
+            if e.value.func.id == 'var':
+                assign = 'var'
+                new = ''
+                val = e.value.args[0].value
+            elif e.value.func.id == 'const':
+                assign = 'const'
+                new = ''
+                val = e.value.args[0].value
+            elif e.value.func.id == 'let':
+                assign = 'let'
+                new = ''
+                val = e.value.args[0].value
+            else:
+                assign = self.config.assign
+                val = self.process_statement(e.value)
+        else:
+            assign = self.config.assign
+            val = self.process_statement(e.value)
         if 'this' in targets:
             return f"{targets} {augment_string}= {new}{val}"
         else:
             if augment or targets.strip() in self.config.assign_special_cases: return f"{targets} {augment_string}= {new}{val}"
-            else: return f"{self.config.assign} {targets} {augment_string}= {new}{val}"
+            else: return f"{assign} {targets} {augment_string}= {new}{val}"
 
     def process_subscript(self, e) -> str:
         try:

--- a/tests/vanillajs/basicsyntax.py
+++ b/tests/vanillajs/basicsyntax.py
@@ -296,7 +296,7 @@ class MyClass:
 ## Class with Inheritance ##
 class MyOtherClass(MyClass):
     def __init__(self):
-        super().__init__()
+        super(MyClass)#.__init__()
         self.my_other_var = "Hello World!"
 
     def my_other_function(self):

--- a/tests/vanillajs/basicsyntax.py
+++ b/tests/vanillajs/basicsyntax.py
@@ -243,6 +243,9 @@ for i in range(0, 10):
     print(i)
 
 ## While Loops ##
+# NOTE: To ensure that this is declared as a `var` and not a `const`, I changed the default assignment to `var`.
+# I also added a new set of special types, so you could alternatively set the default to `const` or even `let` and then override like so:
+# i = var(0)
 i = 0
 while i < 10:
     print(i)
@@ -341,6 +344,15 @@ f1 = lambda: "Hello World!"
 f2 = lambda x: x + 1
 
 f3 = lambda x, y: x + y
+
+
+
+my_special_var = var(25)
+my_special_const = const(25)
+my_special_let = let(25)
+
+# TODO: Multiple assignment...
+# e.g. x, y, z = var(20, 40, 60)
 
 
 

--- a/tests/vanillajs/basicsyntax.py
+++ b/tests/vanillajs/basicsyntax.py
@@ -139,9 +139,9 @@ def greater_than_or_equal_to(a, b):
 # Assignment #
 
 ## Simple assignment ##
-def assign(a, b):
-    a = b
-    return a
+def assign(a):
+    x = a
+    return x
 
 ## Simple addition assignment ##
 def add_assign(a, b):

--- a/tests/vanillajs/basicsyntax.py
+++ b/tests/vanillajs/basicsyntax.py
@@ -361,6 +361,9 @@ my_special_let = let(25)
 ## Ternary ##
 a = 1 if 1 == 1 else 2
 
+# or...
+a2 = ternary(1 == 1, 1, 2)
+
 
 
 # Comprehensions #

--- a/tests/vanillajs/basicsyntax.py
+++ b/tests/vanillajs/basicsyntax.py
@@ -366,11 +366,11 @@ a = 1 if 1 == 1 else 2
 # Comprehensions #
 
 ## List Comprehensions ##
-my_list = [i for i in range(0, 10)]
+##my_list = [i for i in range(0, 10)]
 
 ## Dictionary Comprehensions ##
-my_dict = {i: i for i in range(0, 10)}
+##my_dict2 = {i: i for i in range(0, 10)}
 
 ## Set Comprehensions ##
-my_set = {i for i in range(0, 10)}
+##my_set = {i for i in range(0, 10)}
 


### PR DESCRIPTION
This PR includes a whole lot of new passing syntax test cases.

Another notable milestone is the final decision to completely remove semicolons (except for inside for loop instantiations).

This PR also includes:
* Special classes for defining `const` vs `let` vs `var` (defaults to `var`).
* Some inheritance adjustments.
* A warning about special exception type catching (and how it must be worked into the code logic to match JavaScript).
* Added some optional code context logs for debugging.
* Enabled two different ways of defining ternaries.